### PR TITLE
FTR-105: Working hours on company details is displaying a number instead of an interval

### DIFF
--- a/app/src/main/java/hr/foi/air/servicesync/backend/FirestoreCompanyDetails.kt
+++ b/app/src/main/java/hr/foi/air/servicesync/backend/FirestoreCompanyDetails.kt
@@ -1,6 +1,5 @@
 package hr.foi.air.servicesync.backend
 
-import android.content.Context
 import android.util.Log
 import com.google.firebase.firestore.FirebaseFirestore
 import com.google.firebase.firestore.GeoPoint
@@ -12,7 +11,6 @@ class FirestoreCompanyDetails {
     private var companyName: String = "No name found!"
     private var companyDescription: String = "No description found!"
     private var companyCategory: String = "No category found!"
-    private var companyWorkingHours: Int = 0
     private var companyOpeningTime: String = "0:00"
     private var companyClosingTime: String = "0:00"
     private var companyGeoPoint: GeoPoint = GeoPoint(0.0, 0.0)
@@ -44,21 +42,6 @@ class FirestoreCompanyDetails {
             }
             .addOnFailureListener {
                 onResult("No category found!")
-            }
-    }
-
-    fun loadCompanyWorkingHoursByName(companyName: String, onResult: (Int?) -> Unit) {
-        db.collection("companies")
-            .whereEqualTo("name", companyName)
-            .limit(1)
-            .get()
-            .addOnSuccessListener { documents ->
-                val workingHours = documents.documents.firstOrNull()?.getLong("workingHours")?.toInt()
-                companyWorkingHours = workingHours ?: 0
-                onResult(companyWorkingHours)
-            }
-            .addOnFailureListener {
-                onResult(0)
             }
     }
 

--- a/app/src/main/java/hr/foi/air/servicesync/business/CompanyDetailsHandler.kt
+++ b/app/src/main/java/hr/foi/air/servicesync/business/CompanyDetailsHandler.kt
@@ -16,7 +16,8 @@ class CompanyDetailsHandler {
         companyName: String,
         companyDescription: MutableState<String>,
         companyCategory: MutableState<String>,
-        companyWorkingHours: MutableState<Int>,
+        companyOpeningTime: MutableState<String>,
+        companyClosingTime: MutableState<String>,
         companyGeoPoint: MutableState<GeoPoint?>,
         companyImageUrl: MutableState<String?>,
         reviews: MutableState<List<Review>>,
@@ -33,8 +34,12 @@ class CompanyDetailsHandler {
                 companyCategory.value = category ?: context.getString(R.string.no_category)
             }
 
-            firestoreCompanyDetails.loadCompanyWorkingHoursByName(companyName) { workingHours ->
-                companyWorkingHours.value = workingHours ?: 0
+            firestoreCompanyDetails.loadCompanyOpeningTimeByName(companyName) { openingTime ->
+                companyOpeningTime.value = openingTime ?: "0:00"
+            }
+
+            firestoreCompanyDetails.loadCompanyClosingTimeByName(companyName) { closingTime ->
+                companyClosingTime.value = closingTime ?: "0:00"
             }
 
             firestoreCompanyDetails.loadCompanyGeopointByName(companyName) { geoPoint ->

--- a/app/src/main/java/hr/foi/air/servicesync/business/CompanyDetailsHandler.kt
+++ b/app/src/main/java/hr/foi/air/servicesync/business/CompanyDetailsHandler.kt
@@ -39,7 +39,7 @@ class CompanyDetailsHandler {
             }
 
             firestoreCompanyDetails.loadCompanyClosingTimeByName(companyName) { closingTime ->
-                companyClosingTime.value = closingTime ?: "0:00"
+                companyClosingTime.value = closingTime ?: "23:59"
             }
 
             firestoreCompanyDetails.loadCompanyGeopointByName(companyName) { geoPoint ->

--- a/app/src/main/java/hr/foi/air/servicesync/ui/contents/CompanyDetailsContent.kt
+++ b/app/src/main/java/hr/foi/air/servicesync/ui/contents/CompanyDetailsContent.kt
@@ -58,7 +58,8 @@ fun CompanyDetailsContent(
 
     val companyDescription = remember { mutableStateOf(context.getString(R.string.loading)) }
     val companyCategory = remember { mutableStateOf(context.getString(R.string.loading)) }
-    val companyWorkingHours = remember { mutableStateOf(0) }
+    val companyOpeningTime = remember { mutableStateOf("") }
+    val companyClosingTime = remember { mutableStateOf("") }
     val companyGeoPoint = remember { mutableStateOf<GeoPoint?>(null) }
     val companyImageUrl = remember { mutableStateOf<String?>(null) }
     val reviews = remember { mutableStateOf<List<Review>>(emptyList()) }
@@ -71,7 +72,8 @@ fun CompanyDetailsContent(
             companyName = companyName,
             companyDescription = companyDescription,
             companyCategory = companyCategory,
-            companyWorkingHours = companyWorkingHours,
+            companyClosingTime = companyClosingTime,
+            companyOpeningTime = companyOpeningTime,
             companyGeoPoint = companyGeoPoint,
             companyImageUrl = companyImageUrl,
             reviews = reviews,
@@ -142,7 +144,7 @@ fun CompanyDetailsContent(
                     Spacer(modifier = Modifier.height(25.dp))
                 },
                 supportingContent = {
-                    Text("${companyWorkingHours.value}")
+                    Text("${companyOpeningTime.value} - ${companyClosingTime.value}")
                 }
             )
 


### PR DESCRIPTION
Here is the fixed UI for working hours:
![Screenshot_20250113-201127_ServiceSync 1](https://github.com/user-attachments/assets/ebd801e5-076e-4bb2-a612-8af7021d4d88)

Key changes:

- added companyOpeningTime and companyClosingTime and removed companyWorkingHours
- changed business logic layer class CompanyDetailsHandler (it requires 2 additional params with workingHours removed)
- added calls to existing data access layer methods - loadCompanyOpeningTimeByName loadCompanyClosingTimeByName