### PR TITLE
FTR-103-Saved-reservation-saves-company-name-to-service-name-added authentic timeslots

### DIFF
--- a/app/src/main/java/hr/foi/air/servicesync/backend/FirestoreCompanyDetails.kt
+++ b/app/src/main/java/hr/foi/air/servicesync/backend/FirestoreCompanyDetails.kt
@@ -159,4 +159,16 @@ class FirestoreCompanyDetails {
                 onResult("23:59")
             }
     }
+    fun loadCompanyServicesByName(companyName: String, onResult: (List<String>?) -> Unit) {
+        db.collection("services")
+            .whereEqualTo("companyName", companyName)
+            .get()
+            .addOnSuccessListener { documents ->
+                val services = documents.documents.mapNotNull { it.getString("serviceName") }
+                onResult(services)
+            }
+            .addOnFailureListener {
+                onResult(null)
+            }
+    }
 }

--- a/app/src/main/java/hr/foi/air/servicesync/backend/FirestoreCompanyDetails.kt
+++ b/app/src/main/java/hr/foi/air/servicesync/backend/FirestoreCompanyDetails.kt
@@ -137,8 +137,8 @@ class FirestoreCompanyDetails {
             .document(companyId)
             .get()
             .addOnSuccessListener { document ->
-                val closingTime = document.getString("openingTime")
-                val formattedOpeningTime = closingTime ?: "0:00"
+                val openingTime = document.getString("openingTime")
+                val formattedOpeningTime = openingTime ?: "0:00"
                 onResult(formattedOpeningTime)
             }
             .addOnFailureListener {
@@ -170,4 +170,27 @@ class FirestoreCompanyDetails {
                 onResult(null)
             }
     }
+    fun loadServiceDuration(
+        companyName: String,
+        serviceName: String,
+        onResult: (Int?) -> Unit
+    ) {
+        db.collection("services")
+            .whereEqualTo("companyName", companyName)
+            .whereEqualTo("serviceName", serviceName)
+            .get()
+            .addOnSuccessListener { documents ->
+                if (documents.isEmpty) {
+                    Log.d("ServiceDuration", "No service found for $serviceName and $companyName")
+                    onResult(null)
+                } else {
+                    val duration = documents.firstOrNull()?.getLong("duration")?.toInt()
+                    Log.d("ServiceDuration", "Duration for $serviceName: $duration")
+                    onResult(duration)
+                }
+            }
+
+    }
+
+
 }

--- a/app/src/main/java/hr/foi/air/servicesync/backend/FirestoreCompanyDetails.kt
+++ b/app/src/main/java/hr/foi/air/servicesync/backend/FirestoreCompanyDetails.kt
@@ -1,6 +1,5 @@
 package hr.foi.air.servicesync.backend
 
-import android.content.Context
 import android.util.Log
 import com.google.firebase.firestore.FirebaseFirestore
 import com.google.firebase.firestore.GeoPoint

--- a/app/src/main/java/hr/foi/air/servicesync/backend/FirestoreService.kt
+++ b/app/src/main/java/hr/foi/air/servicesync/backend/FirestoreService.kt
@@ -1,6 +1,5 @@
 package hr.foi.air.servicesync.backend
 
-import android.util.Log
 import com.google.firebase.firestore.FirebaseFirestore
 import java.time.LocalTime
 
@@ -40,39 +39,47 @@ class FirestoreService {
 
     fun getAvailableTimeSlotsAndRange(
         companyId: String,
+        serviceName: String,
         date: Long,
         onSuccess: (List<Long>) -> Unit,
         onFailure: (Exception) -> Unit
     ) {
-        val startOfDay = date - (date % (24 * 60 * 60 * 1000)) // Početak dana
-        val endOfDay = startOfDay + (24 * 60 * 60 * 1000) - 1 // Kraj dana
-        Log.d("start of day", "start: $startOfDay")
-        Log.d("end of day", "end: $endOfDay")
-        val firestoreCompanyDetails = FirestoreCompanyDetails()
+        val startOfDay = date - (date % (24 * 60 * 60 * 1000))
+        val endOfDay = startOfDay + (24 * 60 * 60 * 1000) - 1
 
+        val firestoreCompanyDetails = FirestoreCompanyDetails()
         firestoreCompanyDetails.loadCompanyOpeningTimeById(companyId) { openingTime ->
             firestoreCompanyDetails.loadCompanyClosingTimeById(companyId) { closingTime ->
+                firestoreCompanyDetails.loadServiceDuration(
+                    companyId,
+                    serviceName
+                ) { duration ->
+                    val openingMillis = timeToMillis(openingTime ?: "00:00", startOfDay)
+                    val closingMillis = timeToMillis(closingTime ?: "23:59", startOfDay)
 
-                var openingMillis = timeToMillis(openingTime ?: "00:00", startOfDay)
-                var closingMillis = timeToMillis(closingTime ?: "23:59", startOfDay)
+                    val step = (duration?.toLong() ?: 30L) * 60 * 1000 // default time slot of 30 minutes
+                    val allSlots = (openingMillis - (60 * 60 * 1000) until closingMillis - (60 * 60 * 1000) step step).toList()
 
-                val allSlots = ((openingMillis - (60 * 60 * 1000)) until (closingMillis - (60 * 60 * 1000)) step 30 * 60 * 1000).toList()
-                Log.d("AvailableTimeSlots", "All slots: $allSlots")
+                    db.collection("reservations")
+                        .whereEqualTo("companyId", companyId)
+                        .whereGreaterThanOrEqualTo("reservationDate", startOfDay)
+                        .whereLessThanOrEqualTo("reservationDate", endOfDay)
+                        .get()
+                        .addOnSuccessListener { documents ->
+                            val occupiedSlots = documents.map { it["reservationDate"] as Long }
+                            val availableSlots = allSlots.filter { slotStart ->
+                                occupiedSlots.none { occupied ->
+                                    val slotEnd = slotStart + step
+                                    occupied in slotStart until slotEnd
+                                }
+                            }
 
-                db.collection("reservations")
-                    .whereEqualTo("companyId", companyId)
-                    .whereGreaterThanOrEqualTo("reservationDate", startOfDay)
-                    .whereLessThanOrEqualTo("reservationDate", endOfDay)
-                    .get()
-                    .addOnSuccessListener { documents ->
-                        val occupiedSlots = documents.map { it["reservationDate"] as Long }
-                        val availableSlots = allSlots.filter { it !in occupiedSlots }
-
-                        onSuccess(availableSlots)
-                    }
-                    .addOnFailureListener { exception ->
-                        onFailure(exception)
-                    }
+                            onSuccess(availableSlots)
+                        }
+                        .addOnFailureListener { exception ->
+                            onFailure(exception)
+                        }
+                }
             }
         }
     }

--- a/app/src/main/java/hr/foi/air/servicesync/business/CompanyDetailsHandler.kt
+++ b/app/src/main/java/hr/foi/air/servicesync/business/CompanyDetailsHandler.kt
@@ -20,6 +20,7 @@ class CompanyDetailsHandler {
         companyGeoPoint: MutableState<GeoPoint?>,
         companyImageUrl: MutableState<String?>,
         reviews: MutableState<List<Review>>,
+        services: MutableState<List<String>>,
         isLoading: MutableState<Boolean>,
         firestoreCompanyDetails: FirestoreCompanyDetails,
         reviewHandler: ReviewHandler
@@ -47,6 +48,10 @@ class CompanyDetailsHandler {
 
             reviewHandler.fetchReviews(companyName) { fetchedReviews ->
                 reviews.value = fetchedReviews
+            }
+
+            firestoreCompanyDetails.loadCompanyServicesByName(companyName) { fetchedServices ->
+                services.value = fetchedServices ?: emptyList()
             }
 
             isLoading.value = false

--- a/app/src/main/java/hr/foi/air/servicesync/business/ReservationManager.kt
+++ b/app/src/main/java/hr/foi/air/servicesync/business/ReservationManager.kt
@@ -22,12 +22,14 @@ class ReservationManager(private val firestoreService: FirestoreService) {
 
     fun fetchAvailableSlots(
         companyId: String,
+        serviceName: String,
         dateMillis: Long,
         onSlotsFetched: (List<Long>) -> Unit
     ) {
         firestoreService.getAvailableTimeSlotsAndRange(
-            companyId = companyId,
-            date = dateMillis,
+            companyId,
+            serviceName,
+            dateMillis,
             onSuccess = { slots -> onSlotsFetched(slots) },
             onFailure = { exception ->
                 println("Error fetching available slots: ${exception.message}")

--- a/app/src/main/java/hr/foi/air/servicesync/navigation/AppNavHost.kt
+++ b/app/src/main/java/hr/foi/air/servicesync/navigation/AppNavHost.kt
@@ -68,8 +68,8 @@ fun NavGraphBuilder.AppNavHost(navController: NavHostController) {
     composable("company/{companyName}/{serviceName}") {
         backStackEntry ->
         val companyName = backStackEntry.arguments?.getString("companyName") ?: "Unknown"
-        val serviceName = backStackEntry.arguments?.getString("companyName") ?: "Unknown"
-        ServiceReservationScreen(serviceName, companyName, navController)
+        val serviceName = backStackEntry.arguments?.getString("serviceName") ?: "Unknown"
+        ServiceReservationScreen(serviceName = serviceName, companyName, navController)
 
     }
 

--- a/app/src/main/java/hr/foi/air/servicesync/ui/contents/CompanyDetailsContent.kt
+++ b/app/src/main/java/hr/foi/air/servicesync/ui/contents/CompanyDetailsContent.kt
@@ -62,6 +62,7 @@ fun CompanyDetailsContent(
     val companyGeoPoint = remember { mutableStateOf<GeoPoint?>(null) }
     val companyImageUrl = remember { mutableStateOf<String?>(null) }
     val reviews = remember { mutableStateOf<List<Review>>(emptyList()) }
+    val services = remember { mutableStateOf<List<String>>(emptyList()) }
     val isLoading = remember { mutableStateOf(true) }
 
     LaunchedEffect(companyName) {
@@ -75,6 +76,7 @@ fun CompanyDetailsContent(
             companyGeoPoint = companyGeoPoint,
             companyImageUrl = companyImageUrl,
             reviews = reviews,
+            services = services,
             isLoading = isLoading,
             firestoreCompanyDetails = firestoreCompanyDetails,
             reviewHandler = reviewHandler
@@ -125,9 +127,13 @@ fun CompanyDetailsContent(
                     )
                 },
                 supportingContent = {
-                    ProvidedServicesListItem(serviceName =  companyCategory.value, onServiceClicked = {
-                        navController.navigate("company/${companyName}/${companyCategory.value}")
-                    })
+                    Column {
+                        services.value.forEach { service ->
+                            ProvidedServicesListItem(serviceName = service, onServiceClicked = {
+                                navController.navigate("company/$companyName/$service")
+                            })
+                        }
+                    }
                 }
             )
 

--- a/app/src/main/java/hr/foi/air/servicesync/ui/screens/ServiceReservationScreen.kt
+++ b/app/src/main/java/hr/foi/air/servicesync/ui/screens/ServiceReservationScreen.kt
@@ -89,13 +89,17 @@ fun ServiceReservationScreen(serviceName: String, companyId: String, navControll
                         reservationManager.fetchAvailableSlots(
                             companyId,
                             it
-                        ) { slots -> availableSlots = slots }
+                        ) { slots ->
+                            if (slots.isEmpty()) {
+                                Toast.makeText(context, context.getString(R.string.no_slots), Toast.LENGTH_SHORT).show()
+                            }
+                            availableSlots = slots
+                        }
                     }
                     showDatePicker = false
                 }
             )
         }
-
         Spacer(modifier = Modifier.height(16.dp))
 
         Text(
@@ -159,6 +163,7 @@ fun ServiceReservationScreen(serviceName: String, companyId: String, navControll
                         userId = userId,
                         onSuccess = {
                             println("Reservation saved successfully.")
+                            println("Spremanje rezervacije: companyId=$companyId, serviceName=$serviceName, reservationDate=$selectedSlot, userId=$userId")
                             availableSlots = availableSlots.filter { it != selectedSlot }
                             Toast.makeText(context, context.getString(R.string.reservation_successful), Toast.LENGTH_SHORT).show()
                             selectedSlot = null

--- a/app/src/main/java/hr/foi/air/servicesync/ui/screens/ServiceReservationScreen.kt
+++ b/app/src/main/java/hr/foi/air/servicesync/ui/screens/ServiceReservationScreen.kt
@@ -1,7 +1,6 @@
 package hr.foi.air.servicesync.ui.screens
 
 import android.widget.Toast
-import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
@@ -10,24 +9,12 @@ import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
-import com.example.compose.backgroundDark
-import com.example.compose.backgroundLight
 import com.example.compose.inversePrimaryDarkMediumContrast
 import com.example.compose.inversePrimaryLightMediumContrast
-import com.example.compose.onSurfaceDark
-import com.example.compose.onSurfaceLight
-import com.example.compose.outlineVariantDark
-import com.example.compose.outlineVariantLight
-import com.example.compose.secondaryContainerDarkMediumContrast
-import com.example.compose.secondaryContainerLightMediumContrast
-import com.example.compose.surfaceContainerDark
-import com.example.compose.surfaceContainerLight
 import com.example.compose.surfaceVariantDark
 import com.example.compose.surfaceVariantLight
 import hr.foi.air.servicesync.R

--- a/app/src/main/java/hr/foi/air/servicesync/ui/screens/ServiceReservationScreen.kt
+++ b/app/src/main/java/hr/foi/air/servicesync/ui/screens/ServiceReservationScreen.kt
@@ -70,12 +70,13 @@ fun ServiceReservationScreen(serviceName: String, companyId: String, navControll
                 onDismiss = {
                     showDatePicker = false
                 },
-                onConfirm = {selectedDate ->
-                    selectedDate?.let {
-                        selectedDateMillis = it
+                onConfirm = { selectedDate ->
+                    selectedDate?.let { dateMillis ->
+                        selectedDateMillis = dateMillis
                         reservationManager.fetchAvailableSlots(
                             companyId,
-                            it
+                            serviceName,
+                            dateMillis
                         ) { slots ->
                             if (slots.isEmpty()) {
                                 Toast.makeText(context, context.getString(R.string.no_slots), Toast.LENGTH_SHORT).show()

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -69,4 +69,5 @@
     <string name="future_appointments">Ihre anstehenden Termine:</string>
     <string name="no_future_appointments">Es gibt keine bevorstehenden Fristen.</string>
     <string name="days">Tage</string>
+    <string name="no_slots">Es gibt keine freien Termine!</string>
 </resources>

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -68,4 +68,5 @@
     <string name="future_appointments">Your upcoming appointments:</string>
     <string name="no_future_appointments">There is no future appointments.</string>
     <string name="days">days</string>
+    <string name="no_slots">There are no free dates!</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -68,4 +68,5 @@
     <string name="future_appointments">Sus próximas citas:</string>
     <string name="no_future_appointments">No hay plazos próximos.</string>
     <string name="days">días</string>
+    <string name="no_slots">¡No hay fechas libres!</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -69,4 +69,5 @@
     <string name="future_appointments">Vaši nadolazeći termini:</string>
     <string name="no_future_appointments">Nema nadolazećih termina.</string>
     <string name="days">dana</string>
+    <string name="no_slots">Nema slobodnih termina!</string>
 </resources>


### PR DESCRIPTION
FTR-103:
corrected name of the string that should be loaded while opening ServiceReservationScreen
added a function that loads services associated with a company for use in other layers of the app
added a function that handles loading services associated with a company for use in other layers of the app
added a functionality that loads services associated with a company into the CompanyDetailsContent so a user can choose which service he wants to book
added necessary strings
removed unnecessary imports
added function to load services durations for time slot management and fixed grammar mistakes
refactored getAvailableTimeSlotsAndRange for optimal handling of all it's dependencies
refactored fetchAvailableSlots to include serviceName so it can be referenced when needed
refactored getting available time slots to include serviceName in order to be shown to userrefactored getting available time slots to include serviceName in order to be shown to user


**I used to fetch company name/id (same thing). So I altered the code and some fields and values in the database in order to match document id for each company with the companyId. 
I took extra care not to interfere with the code from my colleagues and I succeeded.**